### PR TITLE
Fix layout shift by inlining body background color

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
       <link rel="preload" as="style" href="heading.css" onload="this.onload=null;this.rel='stylesheet'">
       <noscript><link rel="stylesheet" href="heading.css"></noscript>
 </head>
-<body class="bg-brand-bg text-gray-800 font-sans">
+<body class="bg-brand-bg text-gray-800 font-sans" style="background-color:#fff8f3">
   <!-- Navbar -->
   <nav class="glass fixed w-full z-50 shadow-md">
     <div class="max-w-6xl mx-auto flex items-center justify-between p-4">


### PR DESCRIPTION
## Summary
- Inline background color on `<body>` to prevent layout shift before CSS loads

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68920d75b9e083319613729e5c5c6656