### PR TITLE
Inline body margin to prevent initial layout shift

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,9 @@
     ]
   }
   </script>
+  <style>
+    body { margin: 0; }
+  </style>
   <!-- Fonts -->
       <link rel="preload" as="style" href="main.css" onload="this.onload=null;this.rel='stylesheet'">
       <noscript><link rel="stylesheet" href="main.css"></noscript>


### PR DESCRIPTION
## Summary
- Inline `body { margin: 0; }` so page has zero margin before `main.css` loads, preventing initial layout shift

## Testing
- `npm test` (fails: Missing script "test")
- `node -e "const fs=require('fs');const {JSDOM}=require('jsdom');const html=fs.readFileSync('index.html','utf8');const dom=new JSDOM(html);console.log(dom.window.getComputedStyle(dom.window.document.body).margin);"`


------
https://chatgpt.com/codex/tasks/task_e_6892162fafd483318547aa7431938320