### PR TITLE
Convert comments section into horizontal slider

### DIFF
--- a/main.js
+++ b/main.js
@@ -24,6 +24,26 @@ document.addEventListener('DOMContentLoaded', () => {
         container.style.minHeight = '';
         container.classList.add('fade-in');
 
+        const slider = container.querySelector('.testimonial-slider');
+        if (slider) {
+          const cards = slider.querySelectorAll('.testimonial-card');
+          let index = 0;
+          const show = (i) => {
+            slider.style.transform = `translateX(-${i * 100}%)`;
+          };
+          container.querySelector('#nextTestimonial')?.addEventListener('click', () => {
+            index = (index + 1) % cards.length;
+            show(index);
+          });
+          const prev = container.querySelector('#prevTestimonial');
+          if (prev) {
+            prev.addEventListener('click', () => {
+              index = (index - 1 + cards.length) % cards.length;
+              show(index);
+            });
+          }
+        }
+
         // FAQ accordion
         container.querySelectorAll('.faq-trigger').forEach(btn => {
           btn.addEventListener('click', () => {

--- a/sections.html
+++ b/sections.html
@@ -118,7 +118,8 @@
       <h2 class="font-headline text-4xl drop-shadow-sm mb-4">Yorumlar</h2>
       <p class="text-lg">Kullanıcılarımız ne diyor?</p>
     </div>
-    <div class="testimonial-grid px-6">
+    <div class="relative overflow-hidden px-6">
+      <div class="testimonial-slider">
       <div class="testimonial-card">
         <svg class="testimonial-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M2 5a3 3 0 013-3h14a3 3 0 013 3v9a3 3 0 01-3 3H8l-5 5V5z"/></svg>
         <img loading="lazy" src="https://i.pravatar.cc/80?img=1" alt="Ahmet Y." class="testimonial-avatar" width="80" height="80">
@@ -327,8 +328,10 @@
         </div>
         <p class="italic">"İş hayatım ile özel hayatım arasında denge kurdum."</p>
       </div>
-    </div>
-    </div>
+      </div>
+      <button id="prevTestimonial" class="slider-arrow left" type="button" aria-label="Önceki yorum">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+      </button>
       <button id="nextTestimonial" class="slider-arrow right" type="button" aria-label="Sonraki yorum">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
       </button>

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -47,13 +47,16 @@
       z-index:-1;
     }
 
-    .testimonial-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:20px;max-width:1200px;margin:0 auto;}
-    .testimonial-card{background:#fff;border-radius:16px;box-shadow:0 4px 10px rgba(0,0,0,0.1);padding:24px;text-align:center;transition:transform .3s;min-height:260px;overflow:hidden;display:flex;flex-direction:column;}
+    .testimonial-slider{display:flex;transition:transform .5s;}
+    .testimonial-card{background:#fff;border-radius:16px;box-shadow:0 4px 10px rgba(0,0,0,0.1);padding:24px;text-align:center;transition:transform .3s;min-height:260px;overflow:hidden;display:flex;flex-direction:column;flex:0 0 100%;}
     .testimonial-card:hover{transform:scale(1.05);}
     .testimonial-icon{width:24px;height:24px;color:#8c3600;margin:0 auto 8px;}
-    .testimonial-avatar{width:80px;height:80px;border-radius:50%;object-fit:cover;margin:0 auto 8px;}
+    .testimonial-avatar{display:none;}
     .testimonial-stars{display:flex;justify-content:center;gap:2px;margin:8px 0;}
     .testimonial-stars svg{width:20px;height:20px;fill:#fbbf24;}
+    .slider-arrow{position:absolute;top:50%;transform:translateY(-50%);background:#fff;border-radius:9999px;padding:8px;box-shadow:0 2px 8px rgba(0,0,0,0.1);}
+    .slider-arrow.left{left:10px;}
+    .slider-arrow.right{right:10px;}
     /* Footer */
     footer{
       background:#f8fafc;


### PR DESCRIPTION
## Summary
- Turned testimonial area into horizontal slider and added navigation arrows
- Hid avatars and styled slider controls for a cleaner layout
- Introduced JavaScript to navigate testimonial slides

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689219c711bc8331906287c922893250