### PR TITLE
Show TOC before guide on mobile

### DIFF
--- a/main.css
+++ b/main.css
@@ -1210,7 +1210,7 @@ video {
 }
 
 @media (max-width:768px){
-  .guide-card {
+  .toc-card {
     order:-1;
   }
 }

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -21,7 +21,7 @@
     .guide-card h1 { font-size:2rem; font-weight:700; margin:0 0 16px 0; }
     .guide-card p { font-size:1rem; margin-bottom:32px; }
     #rehber-icerik{max-height:480px;overflow-y:auto;padding:20px;background:#fff;border-radius:12px;box-shadow:0 2px 8px rgba(0,0,0,0.05);}
-    @media (max-width:768px){ .guide-card { order:-1; } }
+    @media (max-width:768px){ .toc-card { order:-1; } }
     .steps{position:relative;display:flex;flex-direction:column;gap:2.5rem;}
     .steps::before{content:"";position:absolute;left:2rem;top:0;bottom:0;width:2px;background:#8c3600;}
     .step{position:relative;padding:1.5rem 1.5rem 1.5rem 4rem;background:rgba(255,255,255,0.7);border-radius:1rem;box-shadow:0 4px 10px rgba(0,0,0,0.1);transition:transform .3s;display:flex;align-items:flex-start;}


### PR DESCRIPTION
## Summary
- Ensure table of contents precedes guide on small screens by reordering elements via CSS.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6892f3d737708331a917c9816fb7df37