### PR TITLE
style: prevent heading overlap

### DIFF
--- a/guide.html
+++ b/guide.html
@@ -30,8 +30,8 @@
         <path d="M22 42h20v10H22z" fill="#fff" stroke="#555" stroke-width="2"/>
         <path d="M16 32v-4M48 32v-4" stroke="#555" stroke-width="2"/>
       </svg>
-      <h1 class="font-headline text-4xl md:text-5xl w-full h-[3rem] md:h-[3.75rem]">Freelance Çağrı Merkezi Rehberi</h1>
-      <p>Evden çağrı merkezi modeli, uzaktan çalışmanın sunduğu avantajlarla işletmeler ve çalışanlar için yeni fırsatlar yaratır.</p>
+      <h1 class="font-headline text-4xl md:text-5xl w-full h-[3rem] md:h-[3.75rem] leading-[3rem] md:leading-[3.75rem]">Freelance Çağrı Merkezi Rehberi</h1>
+      <p class="mt-4 md:mt-6">Evden çağrı merkezi modeli, uzaktan çalışmanın sunduğu avantajlarla işletmeler ve çalışanlar için yeni fırsatlar yaratır.</p>
       <div id="rehber-icerik" class="mt-10 text-left"></div>
     </div>
     <!-- Table of Contents -->


### PR DESCRIPTION
## Summary
- align guide hero heading with explicit line-height
- add top margin to first paragraph for spacing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892f92432648331993a328d7d5dc4c4