### PR TITLE
feat: redesign hero section with split image and gradient

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,15 +107,45 @@
   </nav>
 
   <!-- Hero -->
-  <section id="hero" class="relative min-h-screen flex items-center justify-center overflow-hidden text-center">
-    <div id="hero-bg" class="absolute inset-0 bg-cover bg-center" style="background-image:url('data:image/webp;base64,UklGRrYAAABXRUJQVlA4IKoAAADQBACdASoSAAwAPpE4l0eloyIhMAgAsBIJQBOmUGMFkAFQAMYUTPdQlfPK3aVn0ADOF+/n/DoLVvQLo+qygHQdc43SylXVdbMji2OUVuDT9f+GIp6XsH7m8HfDa/rIy1eBjUwK27Ixi/p7YMm63EYR3CIc1VFsP6B0aqU1sQmKrww1qN9m6Lupg9667rtRqmPfBhUJ2rU8fuPxjWUhNucYhRmIEw9sbawAAA==');filter:blur(20px);transition:filter .5s;"></div>
-    <div class="absolute inset-0 bg-black/60"></div>
-    <div class="relative z-10 max-w-3xl mx-auto px-4 py-24 text-white">
-      <h1 class="font-headline text-4xl sm:text-5xl md:text-6xl drop-shadow-lg mb-6">Freelance Çağrı Merkezi</h1>
-      <p class="text-lg sm:text-xl mb-8">Evden çalış, esnek saatlerle kurumsal projelerde yer al.</p>
-      <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <a href="#" class="bg-brand-orange px-8 py-3 rounded-2xl shadow hover:bg-[#a14b14] transition">Başvur</a>
-        <a href="#neden" class="glass px-8 py-3 rounded-2xl text-brand-orange shadow hover:bg-white/60 transition">Detaylar</a>
+  <section
+    id="hero"
+    class="min-h-screen flex flex-col md:flex-row"
+    style="align-items:stretch;justify-content:stretch;text-align:left;"
+  >
+    <!-- Left image -->
+    <div class="md:w-1/2 w-full h-64 md:h-auto">
+      <img
+        src="src/img/head1.webp"
+        alt="Freelance Çağrı Merkezi"
+        class="w-full h-full object-cover"
+      />
+    </div>
+
+    <!-- Right content with gradient overlay -->
+    <div class="md:w-1/2 w-full relative flex items-center justify-center p-8">
+      <div
+        class="absolute inset-0 bg-gradient-to-br from-brand-orange via-orange-600 to-orange-700"
+        style="clip-path:polygon(10% 0,100% 0,100% 100%,0 100%);"
+      ></div>
+      <div class="relative z-10 max-w-xl text-white">
+        <h1 class="font-headline font-bold text-4xl sm:text-5xl md:text-6xl drop-shadow-lg mb-6">
+          Freelance Çağrı Merkezi
+        </h1>
+        <p class="text-lg sm:text-xl mb-8">
+          Evden çalış, esnek saatlerle kurumsal projelerde yer al.
+        </p>
+        <div class="flex flex-col sm:flex-row gap-4">
+          <a
+            href="#"
+            class="bg-brand-orange text-white px-8 py-4 rounded-2xl font-semibold shadow-lg hover:bg-orange-700 transition"
+            >Başvur</a
+          >
+          <a
+            href="#neden"
+            class="bg-white/20 text-brand-orange px-8 py-4 rounded-2xl font-semibold shadow-lg hover:bg-white/30 transition"
+            >Detaylar</a
+          >
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- redesign hero section with split image on left and diagonal orange gradient overlay on right

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689316eec9788331a619103377465bfb