### PR TITLE
Add responsive hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,10 +72,9 @@
     ]
   }
   </script>
-  <style>
-    body { margin: 0; }
-    #hero { position: relative; min-height: 100vh; display: flex; align-items: center; justify-content: center; text-align: center; overflow: hidden; }
-  </style>
+    <style>
+      body { margin: 0; }
+    </style>
   <!-- Fonts -->
       <link rel="preload" as="style" href="main.css" onload="this.onload=null;this.rel='stylesheet'">
       <noscript><link rel="stylesheet" href="main.css"></noscript>
@@ -106,20 +105,23 @@
     </div>
   </nav>
 
-  <!-- Hero -->
-  <section id="hero" class="relative min-h-screen flex items-center justify-center overflow-hidden text-center">
-    <div id="hero-bg" class="absolute inset-0 bg-cover bg-center" style="background-image:url('data:image/webp;base64,UklGRrYAAABXRUJQVlA4IKoAAADQBACdASoSAAwAPpE4l0eloyIhMAgAsBIJQBOmUGMFkAFQAMYUTPdQlfPK3aVn0ADOF+/n/DoLVvQLo+qygHQdc43SylXVdbMji2OUVuDT9f+GIp6XsH7m8HfDa/rIy1eBjUwK27Ixi/p7YMm63EYR3CIc1VFsP6B0aqU1sQmKrww1qN9m6Lupg9667rtRqmPfBhUJ2rU8fuPxjWUhNucYhRmIEw9sbawAAA==');filter:blur(20px);transition:filter .5s;"></div>
-    <div class="absolute inset-0 bg-black/60"></div>
-    <div class="relative z-10 max-w-3xl mx-auto px-4 py-24 text-white">
-      <h1 class="font-headline text-4xl sm:text-5xl md:text-6xl drop-shadow-lg mb-6">Freelance Çağrı Merkezi</h1>
-      <p class="text-lg sm:text-xl mb-8">Evden çalış, esnek saatlerle kurumsal projelerde yer al.</p>
-      <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <a href="#" class="bg-brand-orange px-8 py-3 rounded-2xl shadow hover:bg-[#a14b14] transition">Başvur</a>
-        <a href="#neden" class="glass px-8 py-3 rounded-2xl text-brand-orange shadow hover:bg-white/60 transition">Detaylar</a>
+    <!-- Hero -->
+    <section id="hero" class="grid min-h-screen grid-cols-1 md:grid-cols-2">
+    <div class="h-64 md:h-full">
+      <img src="src/img/head1.webp" alt="" class="h-full w-full object-cover">
+    </div>
+    <div class="relative flex h-full items-center justify-center overflow-hidden p-8 sm:p-12">
+      <div class="absolute inset-0 bg-gradient-to-br from-[#fba14f] to-[#e3791b] md:[clip-path:polygon(0_0,100%_0,100%_100%,0_75%)]"></div>
+      <div class="relative z-10 text-center text-white">
+        <h1 class="mb-4 text-3xl font-bold drop-shadow sm:text-4xl md:text-5xl">Freelance Çağrı Merkezi</h1>
+        <p class="mb-8 text-lg drop-shadow sm:text-xl md:text-2xl">Evden çalış, esnek saatlerle kurumsal projelerde yer al.</p>
+        <div class="flex justify-center gap-4">
+          <a href="#" class="rounded bg-[#e3791b] px-8 py-4 text-lg font-semibold text-white shadow-lg">Başvur</a>
+          <a href="#" class="rounded bg-white px-8 py-4 text-lg font-semibold text-[#e3791b] shadow-lg">Detaylar</a>
+        </div>
       </div>
     </div>
   </section>
-
   <div id="lazy-sections" style="min-height:100vh"></div>
   <!-- Scripts -->
   <script src="main.js" defer></script>


### PR DESCRIPTION
## Summary
- replace hero with split layout: left image, right gradient overlay with CTAs
## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689318cd06dc83318dfe0318657510ac