### PR TITLE
feat: redesign hero section with asymmetric layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,10 @@
   </script>
   <style>
     body { margin: 0; }
-    #hero { position: relative; min-height: 100vh; display: flex; align-items: center; justify-content: center; text-align: center; overflow: hidden; }
+    #hero { position: relative; min-height: 100vh; display: flex; align-items: center; overflow: hidden; }
+    @media (min-width:768px){
+      .hero-img{ clip-path: polygon(0 0, 70% 0, 100% 100%, 0 100%); }
+    }
   </style>
   <!-- Fonts -->
       <link rel="preload" as="style" href="main.css" onload="this.onload=null;this.rel='stylesheet'">
@@ -107,15 +110,20 @@
   </nav>
 
   <!-- Hero -->
-  <section id="hero" class="relative min-h-screen flex items-center justify-center overflow-hidden text-center">
-    <div id="hero-bg" class="absolute inset-0 bg-cover bg-center" style="background-image:url('data:image/webp;base64,UklGRrYAAABXRUJQVlA4IKoAAADQBACdASoSAAwAPpE4l0eloyIhMAgAsBIJQBOmUGMFkAFQAMYUTPdQlfPK3aVn0ADOF+/n/DoLVvQLo+qygHQdc43SylXVdbMji2OUVuDT9f+GIp6XsH7m8HfDa/rIy1eBjUwK27Ixi/p7YMm63EYR3CIc1VFsP6B0aqU1sQmKrww1qN9m6Lupg9667rtRqmPfBhUJ2rU8fuPxjWUhNucYhRmIEw9sbawAAA==');filter:blur(20px);transition:filter .5s;"></div>
-    <div class="absolute inset-0 bg-black/60"></div>
-    <div class="relative z-10 max-w-3xl mx-auto px-4 py-24 text-white">
-      <h1 class="font-headline text-4xl sm:text-5xl md:text-6xl drop-shadow-lg mb-6">Freelance Çağrı Merkezi</h1>
+  <section id="hero" class="relative min-h-screen overflow-hidden flex items-center">
+    <div class="absolute inset-0 flex">
+      <div class="hero-img w-full md:w-2/3 h-full">
+        <img src="src/img/head1.webp" alt="Ofis" class="w-full h-full object-cover">
+      </div>
+      <div class="hidden md:block flex-1 bg-gradient-to-br from-brand-orange to-orange-300"></div>
+    </div>
+    <div class="absolute inset-0 bg-black/40 md:bg-transparent"></div>
+    <div class="relative z-10 ml-auto max-w-lg p-8 sm:p-12 text-right text-white bg-white/20 backdrop-blur-md rounded-3xl md:-translate-x-12">
+      <h1 class="font-headline text-4xl sm:text-5xl md:text-6xl drop-shadow mb-6">Freelance Çağrı Merkezi</h1>
       <p class="text-lg sm:text-xl mb-8">Evden çalış, esnek saatlerle kurumsal projelerde yer al.</p>
-      <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <a href="#" class="bg-brand-orange px-8 py-3 rounded-2xl shadow hover:bg-[#a14b14] transition">Başvur</a>
-        <a href="#neden" class="glass px-8 py-3 rounded-2xl text-brand-orange shadow hover:bg-white/60 transition">Detaylar</a>
+      <div class="flex flex-col sm:flex-row gap-4 justify-end">
+        <a href="#basvur" class="bg-brand-orange px-8 py-4 rounded-2xl text-lg font-semibold shadow hover:bg-[#a14b14] transition">Başvur</a>
+        <a href="#detay" class="px-8 py-4 rounded-2xl text-lg font-semibold bg-white/80 text-brand-orange border border-brand-orange hover:bg-white transition">Detaylar</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- apply diagonal clip-path hero image and right-aligned glass panel
- shift CTA buttons to right and overlap gradient for asymmetrical design

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68932f7a3ac883319e410ae5ddadf326