### PR TITLE
Add diagonal layout and asymmetric card styling

### DIFF
--- a/diagonal.css
+++ b/diagonal.css
@@ -1,0 +1,22 @@
+/* Diagonal layout and asymmetric cards */
+.diagonal-section {
+  transform: skewY(-4deg);
+  transform-origin: top left;
+}
+.diagonal-section > * {
+  transform: skewY(4deg);
+}
+.asymmetric > * {
+  transform: rotate(-3deg);
+}
+.asymmetric > *:nth-child(even) {
+  transform: rotate(3deg);
+}
+@media (min-width:768px) {
+  .asymmetric > * {
+    margin-top: 1rem;
+  }
+  .asymmetric > *:nth-child(even) {
+    margin-top: 0;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
       </style>
       <link rel="preload" as="style" href="heading.css" onload="this.onload=null;this.rel='stylesheet'">
       <noscript><link rel="stylesheet" href="heading.css"></noscript>
+      <link rel="stylesheet" href="diagonal.css">
 </head>
   <body>
   <!-- Navbar -->
@@ -110,7 +111,7 @@
   </nav>
 
   <!-- Hero -->
-  <section id="hero" class="relative min-h-screen overflow-hidden flex items-center">
+  <section id="hero" class="relative min-h-screen overflow-hidden flex items-center diagonal-section">
     <div class="absolute inset-0 flex">
       <div class="hero-img w-full md:w-2/3 h-full">
         <img src="src/img/head1.webp" alt="Ofis" class="w-full h-full object-cover">

--- a/sections.html
+++ b/sections.html
@@ -1,12 +1,12 @@
   <!-- Neden Biz -->
-  <section id="neden" class="relative py-20 overflow-hidden">
+  <section id="neden" class="relative py-20 overflow-hidden diagonal-section">
     <div class="absolute inset-0 bg-[url('src/img/nedenbiz.webp')] bg-cover bg-center filter blur-sm opacity-60"></div>
     <div class="absolute inset-0 bg-white/50"></div>
     <div class="relative max-w-6xl mx-auto text-center mb-12">
       <h2 class="font-headline text-4xl md:text-5xl font-bold drop-shadow-sm mb-4">Neden Biz?</h2>
       <p class="text-lg">Bizimle çalışmanın avantajlarını keşfedin.</p>
     </div>
-    <div class="relative max-w-6xl mx-auto grid gap-8 md:grid-cols-3 px-6">
+    <div class="relative max-w-6xl mx-auto grid gap-8 md:grid-cols-3 px-6 asymmetric">
       <div class="glass rounded-2xl p-8 shadow-lg bg-gradient-to-br from-blue-100 via-blue-200 to-blue-300 hover:scale-105 transition-transform duration-300 overflow-hidden min-h-[260px]">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-12 h-12 mx-auto mb-4 text-blue-700" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 4.5v2.25m0 10.5V19.5m6-15v2.25m0 10.5V19.5M4.5 9h2.25m10.5 0H19.5m-15 6h2.25m10.5 0H19.5M7.5 7.5h9v9h-9v-9z" />
@@ -32,9 +32,9 @@
   </section>
 
   <!-- Makale / Rehber -->
-    <section id="rehber" class="relative py-20 overflow-hidden">
+    <section id="rehber" class="relative py-20 overflow-hidden diagonal-section">
     <div class="absolute inset-0 bg-[url('src/img/footer.webp')] bg-cover bg-center opacity-60"></div>
-    <div class="guide-container relative z-10">
+    <div class="guide-container relative z-10 asymmetric">
       <div class="guide-card">
         <svg class="illustration" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
           <circle cx="32" cy="24" r="12" fill="#ffe0b2" stroke="#555" stroke-width="2"/>
@@ -68,7 +68,7 @@
   </section>
 
   <!-- Kariyer Yolculuğu -->
-  <section id="kariyer" class="relative py-20 overflow-hidden">
+  <section id="kariyer" class="relative py-20 overflow-hidden diagonal-section">
     <div class="absolute inset-0 bg-[url('src/img/kariyeryolculugu.webp')] bg-cover bg-center filter blur-sm opacity-60"></div>
     <div class="absolute inset-0 bg-white/60"></div>
     <div class="relative max-w-4xl mx-auto mb-12 text-center">
@@ -76,7 +76,7 @@
       <p class="text-lg">Adım adım gelişimine eşlik ediyoruz.</p>
     </div>
     <div class="relative max-w-5xl mx-auto px-6">
-      <div class="steps">
+      <div class="steps asymmetric">
         <div class="step">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 4h16v16H4z" />
@@ -113,13 +113,13 @@
   </section>
 
   <!-- Yorumlar -->
-  <section id="yorumlar" class="py-20">
+  <section id="yorumlar" class="py-20 diagonal-section">
     <div class="max-w-6xl mx-auto mb-12 text-center">
       <h2 class="font-headline text-4xl drop-shadow-sm mb-4">Yorumlar</h2>
       <p class="text-lg">Kullanıcılarımız ne diyor?</p>
     </div>
     <div class="relative overflow-hidden px-6">
-      <div class="testimonial-slider">
+      <div class="testimonial-slider asymmetric">
       <div class="testimonial-card">
         <svg class="testimonial-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M2 5a3 3 0 013-3h14a3 3 0 013 3v9a3 3 0 01-3 3H8l-5 5V5z"/></svg>
         <img loading="lazy" src="https://i.pravatar.cc/80?img=1" alt="Ahmet Y." class="testimonial-avatar" width="80" height="80">
@@ -339,11 +339,11 @@
   </section>
 
   <!-- SSS -->
-  <section id="sss" class="py-20 bg-white/40">
+  <section id="sss" class="py-20 bg-white/40 diagonal-section">
     <div class="max-w-6xl mx-auto mb-12 text-center">
       <h2 class="font-headline text-4xl drop-shadow-sm mb-4">Sık Sorulan Sorular</h2>
     </div>
-    <div class="max-w-6xl mx-auto space-y-4 px-6">
+    <div class="max-w-6xl mx-auto space-y-4 px-6 asymmetric">
       <div class="faq-item bg-white rounded-2xl shadow transition-all hover:shadow-lg hover:scale-105">
         <button id="faq-trigger-1" class="faq-trigger w-full flex justify-between items-center p-6 text-left" aria-expanded="false" aria-controls="faq1">
           <span class="flex items-center gap-4">
@@ -460,8 +460,8 @@
   </section>
 
   <!-- Footer -->
-  <footer>
-    <div class="footer-top">
+  <footer class="diagonal-section">
+    <div class="footer-top asymmetric">
       <div class="logo">Freelance Call Center</div>
       <div class="social">
         <a href="#" aria-label="LinkedIn">


### PR DESCRIPTION
## Summary
- add `diagonal.css` for skewed sections and rotated card groups
- apply diagonal and asymmetric classes to hero and content sections

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_6893321c9ca48331a70abe194e779b4f