### PR TITLE
Remove diagonal layout from non-hero sections

### DIFF
--- a/diagonal.css
+++ b/diagonal.css
@@ -1,4 +1,4 @@
-/* Diagonal layout and asymmetric cards */
+/* Diagonal layout */
 .diagonal-section {
   transform: skewY(-4deg);
   transform-origin: top left;
@@ -6,29 +6,6 @@
 .diagonal-section > * {
   transform: skewY(4deg);
 }
-.asymmetric > * {
-  transform: rotate(-3deg);
-}
-.asymmetric > *:nth-child(even) {
-  transform: rotate(3deg);
-}
-@media (min-width:768px) {
-  .asymmetric > * {
-    margin-top: 1rem;
-  }
-  .asymmetric > *:nth-child(even) {
-    margin-top: 0;
-  }
-}
-
-/* Skewed cards used in specific sections */
-.skewed > * {
-  transform: rotate(-3deg) skewY(-2deg);
-}
-.skewed > *:nth-child(even) {
-  transform: rotate(3deg) skewY(2deg);
-}
-
 /* Wave dividers separating sections */
 .wave {
   width: 100%;
@@ -75,10 +52,3 @@
   filter: brightness(1.05);
 }
 
-/* Tilted cards for Neden Biz section */
-.neden-card {
-  transform: rotate(-2deg) skewY(-1deg);
-}
-.neden-card:nth-child(even) {
-  transform: rotate(2deg) skewY(1deg);
-}

--- a/index.html
+++ b/index.html
@@ -74,10 +74,18 @@
   </script>
   <style>
     body { margin: 0; }
-    #hero { position: relative; min-height: 100vh; display: flex; align-items: center; overflow: hidden; }
-    @media (min-width:768px){
-      .hero-img{ clip-path: polygon(0 0, 70% 0, 100% 100%, 0 100%); }
+    #hero { position: relative; width: 100vw; height: 100vh; overflow: hidden; }
+    #hero .hero-media,
+    #hero .hero-overlay {
+      position: absolute;
+      inset: 0;
+      width: 100vw;
+      height: 100vh;
+      -webkit-clip-path: polygon(0% 0%, 50% 0%, 100% 100%, 0% 100%);
+              clip-path: polygon(0% 0%, 50% 0%, 100% 100%, 0% 100%);
     }
+    #hero .hero-media { object-fit: cover; }
+    #hero .hero-overlay { background: rgba(0,0,0,0.6); }
   </style>
   <!-- Fonts -->
       <link rel="preload" as="style" href="main.css" onload="this.onload=null;this.rel='stylesheet'">
@@ -111,15 +119,10 @@
   </nav>
 
   <!-- Hero -->
-  <section id="hero" class="relative min-h-screen overflow-hidden flex items-center diagonal-section">
-    <div class="absolute inset-0 flex">
-      <div class="hero-img w-full md:w-2/3 h-full">
-        <img src="src/img/head1.webp" alt="Ofis" class="w-full h-full object-cover">
-      </div>
-      <div class="hidden md:block flex-1 bg-gradient-to-br from-brand-orange to-orange-300"></div>
-    </div>
-    <div class="absolute inset-0 bg-black/40 md:bg-transparent"></div>
-    <div class="relative z-10 ml-auto max-w-lg p-8 sm:p-12 text-right text-white bg-white/20 backdrop-blur-md rounded-3xl md:-translate-x-12">
+  <section id="hero" class="flex items-center justify-end bg-gradient-to-br from-brand-orange to-orange-300">
+    <img src="src/img/head1.webp" alt="Ofis" class="hero-media">
+    <div class="hero-overlay"></div>
+    <div class="relative z-10 max-w-lg p-8 sm:p-12 text-right text-white bg-white/20 backdrop-blur-md rounded-3xl">
       <h1 class="font-headline text-4xl sm:text-5xl md:text-6xl drop-shadow mb-6">Freelance Çağrı Merkezi</h1>
       <p class="text-lg sm:text-xl mb-8">Evden çalış, esnek saatlerle kurumsal projelerde yer al.</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-end">

--- a/sections.html
+++ b/sections.html
@@ -1,5 +1,5 @@
   <!-- Neden Biz -->
-  <section id="neden" class="relative py-20 overflow-hidden diagonal-section">
+  <section id="neden" class="relative py-20 overflow-hidden">
     <svg class="wave wave-top" viewBox="0 0 1440 100" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M0 0 C 240 100 480 -100 720 0 C 960 100 1200 -100 1440 0 V100 H0 Z" fill="#fff"/>
     </svg>
@@ -10,21 +10,21 @@
       <p class="text-lg">Bizimle çalışmanın avantajlarını keşfedin.</p>
     </div>
     <div class="relative max-w-6xl mx-auto grid gap-8 sm:grid-cols-2 md:grid-cols-3 px-6">
-      <div class="neden-card rounded-2xl p-8 bg-white shadow-lg blob-shadow transition-transform duration-300 hover:scale-105">
+      <div class="rounded-2xl p-8 bg-white shadow-lg blob-shadow transition-transform duration-300 hover:scale-105">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-12 h-12 mx-auto mb-4 text-blue-700" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 4.5v2.25m0 10.5V19.5m6-15v2.25m0 10.5V19.5M4.5 9h2.25m10.5 0H19.5m-15 6h2.25m10.5 0H19.5M7.5 7.5h9v9h-9v-9z" />
         </svg>
         <h3 class="font-headline text-2xl font-semibold mb-4">Güçlü Teknoloji</h3>
         <p class="text-gray-800">Gelişmiş altyapı ve araçlarla verimli çalışma.</p>
       </div>
-      <div class="neden-card rounded-2xl p-8 bg-white shadow-lg blob-shadow transition-transform duration-300 hover:scale-105">
+      <div class="rounded-2xl p-8 bg-white shadow-lg blob-shadow transition-transform duration-300 hover:scale-105">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-12 h-12 mx-auto mb-4 text-purple-700" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
         <h3 class="font-headline text-2xl font-semibold mb-4">Esnek Saatler</h3>
         <p class="text-gray-800">Hayatına uygun çalışma takvimi oluştur.</p>
       </div>
-      <div class="neden-card rounded-2xl p-8 bg-white shadow-lg blob-shadow transition-transform duration-300 hover:scale-105">
+      <div class="rounded-2xl p-8 bg-white shadow-lg blob-shadow transition-transform duration-300 hover:scale-105">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-12 h-12 mx-auto mb-4 text-green-700" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 1.5v9m0 0a3 3 0 01-3-3V3m3 7.5a3 3 0 003-3V3m-3 13.5v6m-3 0h6" />
         </svg>
@@ -38,9 +38,9 @@
   </section>
 
   <!-- Makale / Rehber -->
-    <section id="rehber" class="relative py-20 overflow-hidden diagonal-section">
+    <section id="rehber" class="relative py-20 overflow-hidden">
     <div class="absolute inset-0 bg-[url('src/img/footer.webp')] bg-cover bg-center opacity-60"></div>
-    <div class="guide-container relative z-10 asymmetric">
+    <div class="guide-container relative z-10">
       <div class="guide-card">
         <svg class="illustration" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
           <circle cx="32" cy="24" r="12" fill="#ffe0b2" stroke="#555" stroke-width="2"/>
@@ -74,7 +74,7 @@
   </section>
 
   <!-- Kariyer Yolculuğu -->
-  <section id="kariyer" class="relative py-20 overflow-hidden diagonal-section">
+  <section id="kariyer" class="relative py-20 overflow-hidden">
     <svg class="wave wave-top" viewBox="0 0 1440 100" preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M0 0 C 240 100 480 -100 720 0 C 960 100 1200 -100 1440 0 V100 H0 Z" fill="#fff"/>
     </svg>
@@ -85,7 +85,7 @@
       <p class="text-lg">Adım adım gelişimine eşlik ediyoruz.</p>
     </div>
     <div class="relative max-w-5xl mx-auto px-6">
-      <div class="steps skewed">
+      <div class="steps">
         <div class="step blob-shadow hover-glow">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 4h16v16H4z" />
@@ -125,13 +125,13 @@
   </section>
 
   <!-- Yorumlar -->
-  <section id="yorumlar" class="py-20 diagonal-section">
+  <section id="yorumlar" class="py-20">
     <div class="max-w-6xl mx-auto mb-12 text-center">
       <h2 class="font-headline text-4xl drop-shadow-sm mb-4">Yorumlar</h2>
       <p class="text-lg">Kullanıcılarımız ne diyor?</p>
     </div>
     <div class="relative overflow-hidden px-6">
-      <div class="testimonial-slider asymmetric">
+      <div class="testimonial-slider">
       <div class="testimonial-card">
         <svg class="testimonial-icon" viewBox="0 0 24 24" fill="currentColor"><path d="M2 5a3 3 0 013-3h14a3 3 0 013 3v9a3 3 0 01-3 3H8l-5 5V5z"/></svg>
         <img loading="lazy" src="https://i.pravatar.cc/80?img=1" alt="Ahmet Y." class="testimonial-avatar" width="80" height="80">
@@ -351,11 +351,11 @@
   </section>
 
   <!-- SSS -->
-  <section id="sss" class="py-20 bg-white/40 diagonal-section">
+  <section id="sss" class="py-20 bg-white/40">
     <div class="max-w-6xl mx-auto mb-12 text-center">
       <h2 class="font-headline text-4xl drop-shadow-sm mb-4">Sık Sorulan Sorular</h2>
     </div>
-    <div class="max-w-6xl mx-auto space-y-4 px-6 asymmetric">
+    <div class="max-w-6xl mx-auto space-y-4 px-6">
       <div class="faq-item bg-white rounded-2xl shadow transition-all hover:shadow-lg hover:scale-105">
         <button id="faq-trigger-1" class="faq-trigger w-full flex justify-between items-center p-6 text-left" aria-expanded="false" aria-controls="faq1">
           <span class="flex items-center gap-4">
@@ -472,8 +472,8 @@
   </section>
 
   <!-- Footer -->
-  <footer class="diagonal-section">
-    <div class="footer-top asymmetric">
+  <footer>
+    <div class="footer-top">
       <div class="logo">Freelance Call Center</div>
       <div class="social">
         <a href="#" aria-label="LinkedIn">


### PR DESCRIPTION
## Summary
- retain diagonal skew effect only in the hero by pruning extra diagonal CSS rules
- restore standard layout for subsequent sections by removing diagonal-related classes
- add full-screen hero with diagonal clip-path background and overlay for readability
- ensure hero diagonal clip-path works on mobile with `-webkit-clip-path`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893424c06408331b5ab127e449c021d