### PR TITLE
Reduce CLS in hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,23 @@
         display: flex;
         gap: 1rem;
       }
+      #hero h1 {
+        min-height: 2.5rem;
+      }
+      @media (min-width:640px) {
+        #hero h1 { min-height: 3rem; }
+      }
+      @media (min-width:768px) {
+        #hero h1 { min-height: 3.75rem; }
+      }
+      #hero .btn-primary,
+      #hero .btn-secondary {
+        min-width: 8rem;
+        min-height: 3.5rem;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
       #hero .btn-primary {
         background: #bf360c;
         color: #fff;
@@ -186,6 +203,7 @@
       }
     </style>
   <!-- Fonts -->
+      <link rel="preload" as="font" href="src/fonts/arial.woff2" type="font/woff2" crossorigin>
       <link rel="preload" as="style" href="main.css" onload="this.onload=null;this.rel='stylesheet'">
       <noscript><link rel="stylesheet" href="main.css"></noscript>
       <style>
@@ -204,7 +222,7 @@
   <!-- Navbar -->
 <nav class="glass fixed w-full z-50 shadow-md">
   <div class="max-w-6xl mx-auto flex items-center justify-between p-4">
-    <a href="#" class="font-headline text-2xl text-brand-orange drop-shadow-sm inline-block min-h-[2rem]">
+    <a href="#" class="font-headline text-2xl text-brand-orange drop-shadow-sm inline-block">
       FreelanceCall
     </a>
     <div>

--- a/main.css
+++ b/main.css
@@ -681,6 +681,10 @@ video {
   min-height: 2rem;
 }
 
+.min-h-\[2\.5rem\] {
+  min-height: 2.5rem;
+}
+
 .min-h-screen {
   min-height: 100vh;
 }
@@ -699,6 +703,18 @@ video {
 
 .w-full {
   width: 100%;
+}
+
+@media (min-width: 640px) {
+  .sm\:min-h-\[3rem\] {
+    min-height: 3rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .md\:min-h-\[3\.75rem\] {
+    min-height: 3.75rem;
+  }
 }
 
 .max-w-2xl {
@@ -1083,9 +1099,9 @@ video {
 @font-face{
   font-family:'Arial';
 
-  src:local('Arial'),local('ArialMT'),local('sans-serif');
+  src:url('src/fonts/arial.woff2') format('woff2'),local('Arial'),local('ArialMT'),local('sans-serif');
 
-  font-display:swap
+  font-display:swap;
 }
 
 .glass {

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -2,7 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-@font-face{font-family:'Arial';src:local('Arial'),local('ArialMT'),local('sans-serif');font-display:swap}
+@font-face{font-family:'Arial';src:url('src/fonts/arial.woff2') format('woff2'),local('Arial'),local('ArialMT'),local('sans-serif');font-display:swap;}
 
     .glass { background: rgba(255,255,255,0.4); backdrop-filter: blur(10px); }
     .fade-in { animation: fadeIn 1s ease forwards; opacity:0 }


### PR DESCRIPTION
## Summary
- reserve space for hero headline across breakpoints to eliminate layout shifts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68936ab16d6883319f9db93ce27aa7cc