### PR TITLE
feat: add responsive hero image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@ This project includes a basic service worker to cache core assets for faster rep
 - **Compression**: Enable Gzip or Brotli on your hosting or CDN to reduce payload size.
 - **CDN**: Serve static assets via a CDN for better global performance.
 
+### Image optimization
+
+The hero section preloads `src/img/head1.webp` and now supports a responsive source set. Create a 768 px-wide variant and place it at `src/img/head1-768.webp` to cut transfer size on small screens:
+
+```bash
+cwebp -q 80 head1.webp -resize 768 512 -o head1-768.webp
+```
+
+Alternatively, install `sharp` and `imagetools-core` and run the included generator:
+
+```bash
+npm install sharp imagetools-core
+node generate-images.js
+```
+
 ## Development
 
 Install dependencies and run a local server if needed.

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <meta name="twitter:image" content="https://example.com/head1.webp" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preload" as="image" href="src/img/head1.webp" fetchpriority="high">
+  <link rel="preload" as="image" href="src/img/head1.webp" imagesrcset="src/img/head1-768.webp 768w, src/img/head1.webp 1536w" imagesizes="100vw" fetchpriority="high">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -245,7 +245,7 @@
   <!-- Hero -->
   <section id="hero">
     <div class="bg-image">
-      <img src="src/img/head1.webp" width="1536" height="1024" fetchpriority="high" decoding="async" alt="">
+      <img src="src/img/head1.webp" srcset="src/img/head1-768.webp 768w, src/img/head1.webp 1536w" sizes="100vw" width="1536" height="1024" fetchpriority="high" decoding="async" alt="">
     </div>
     <div class="bg-gradient"></div>
     <div class="content">


### PR DESCRIPTION
## Summary
- preload hero image with responsive source set
- serve 768 px and 1536 px variants via `srcset`
- document how to generate optimized images

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689457f7f1588331ab28c7dd226f222e