### PR TITLE
Expose article content to search bots

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <title>Freelance Çağrı Merkezi</title>
   <meta name="description" content="Evden çalış, esnek saatlerle kurumsal projelerde yer al." />
   <meta name="keywords" content="freelance çağrı merkezi, evden çalışma, çağrı merkezi işi" />
+  <meta name="robots" content="index, follow" />
+  <meta name="googlebot" content="index, follow" />
   <link rel="canonical" href="https://example.com/" />
   <meta property="og:title" content="Freelance Çağrı Merkezi" />
   <meta property="og:description" content="Evden çalış, esnek saatlerle kurumsal projelerde yer al." />

--- a/main.js
+++ b/main.js
@@ -87,6 +87,12 @@ document.addEventListener('DOMContentLoaded', () => {
         });
       });
   };
+  const isBot = /bot|crawl|slurp|spider/i.test(navigator.userAgent);
+
+  if (isBot) {
+    loadSections();
+    return;
+  }
 
   const observer = new IntersectionObserver(entries => {
     entries.forEach(entry => {

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://example.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/</loc>
+  </url>
+  <url>
+    <loc>https://example.com/sections.html</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- allow search engines to index site via robots.txt and sitemap
- load lazy sections for bots and add robot meta tags to main page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68945f7039c4833199ecd5172bfcce8b