### PR TITLE
Allow indexing by removing noindex X-Robots-Tag

### DIFF
--- a/build.js
+++ b/build.js
@@ -18,6 +18,9 @@ async function build() {
   const processed = await critters.process(html);
   fs.writeFileSync(path.join(outDir, 'index.html'), processed);
   fs.copyFileSync('sections.html', path.join(outDir, 'sections.html'));
+  if (fs.existsSync('serve.json')) {
+    fs.copyFileSync('serve.json', path.join(outDir, 'serve.json'));
+  }
 
   for (const asset of ['main.css', 'heading.css', 'diagonal.css', 'main.js', 'guide.js', 'sw.js']) {
     if (fs.existsSync(asset)) {

--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "**/*",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "index, follow"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `serve.json` to override default `X-Robots-Tag: noindex`
- copy `serve.json` into `dist` during build

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run serve` & `curl -I http://localhost:3000`

------
https://chatgpt.com/codex/tasks/task_e_68947cd8f8808331948cbc12f4e897d1