### PR TITLE
Enhance Rehber section with fixed background and toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,8 @@
   </section>
 
   <!-- Rehber -->
-  <section id="rehber-wrapper" class="py-16 max-w-7xl mx-auto px-4 lg:flex lg:gap-8">
+  <section id="rehber-wrapper" class="py-16 px-4" style="background-image: linear-gradient(rgba(255,255,255,0.9), rgba(255,255,255,0.9)), url('src/img/footer.webp'); background-attachment: fixed; background-size: cover; background-position: center;">
+    <div class="max-w-7xl mx-auto lg:flex lg:gap-8">
     <aside class="lg:w-64 h-max lg:sticky lg:top-24 bg-white/50 backdrop-blur-md rounded-xl shadow-lg p-4 mb-8 lg:mb-0">
       <nav id="rehber-nav" class="space-y-2 text-sm">
         <a href="#gerekli-ekipmanlar" class="block hover:underline">Gerekli Ekipmanlar</a>
@@ -532,6 +533,7 @@
       <div class="mt-6">
         <button id="rehber-toggle" class="px-6 py-2 rounded-2xl font-semibold text-white bg-brand-orange hover:bg-orange-600 shadow-md">Devamını Oku</button>
       </div>
+    </div>
     </div>
   </section>
 

--- a/main.js
+++ b/main.js
@@ -101,16 +101,16 @@ document.addEventListener('DOMContentLoaded', () => {
   const nav = document.getElementById('rehber-nav');
   if (toggle && extra) {
     toggle.addEventListener('click', () => {
-      extra.classList.remove('hidden');
-      toggle.remove();
+      const isHidden = extra.classList.toggle('hidden');
+      toggle.textContent = isHidden ? 'Devamını Oku' : 'Daha Az Göster';
     });
   }
-  if (nav && extra) {
+  if (nav && extra && toggle) {
     nav.querySelectorAll('a').forEach(link => {
       link.addEventListener('click', () => {
         if (extra.classList.contains('hidden')) {
           extra.classList.remove('hidden');
-          toggle?.remove();
+          toggle.textContent = 'Daha Az Göster';
         }
       });
     });


### PR DESCRIPTION
## Summary
- Add fixed `footer.webp` background with light overlay for the Rehber section
- Toggle button now reveals or hides extra guidance content and switches between "Devamını Oku" and "Daha Az Göster"

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894b1fed1c483319e73245c0488034a