### PR TITLE
Optimize hero image responsive sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <meta name="twitter:image" content="https://example.com/head1.webp" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="preload" as="image" href="src/img/head1.webp" imagesrcset="src/img/head1-480.webp 480w, src/img/head1-768.webp 768w, src/img/head1-1280.webp 1280w, src/img/head1-1536.webp 1536w" imagesizes="100vw" fetchpriority="high">
+  <link rel="preload" as="image" href="src/img/head1.webp" imagesrcset="src/img/head1-480.webp 480w, src/img/head1-768.webp 768w, src/img/head1-1280.webp 1280w, src/img/head1-1536.webp 1536w" imagesizes="(min-width: 768px) 50vw, 100vw" fetchpriority="high">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -361,7 +361,7 @@
   <!-- Hero -->
   <section id="hero">
     <div class="bg-image">
-      <img src="src/img/head1.webp" srcset="src/img/head1-480.webp 480w, src/img/head1-768.webp 768w, src/img/head1-1280.webp 1280w, src/img/head1-1536.webp 1536w" sizes="100vw" width="1536" height="1024" fetchpriority="high" decoding="async" alt="">
+      <img src="src/img/head1.webp" srcset="src/img/head1-480.webp 480w, src/img/head1-768.webp 768w, src/img/head1-1280.webp 1280w, src/img/head1-1536.webp 1536w" sizes="(min-width: 768px) 50vw, 100vw" width="1536" height="1024" fetchpriority="high" decoding="async" alt="">
     </div>
     <div class="bg-gradient"></div>
     <div class="content">


### PR DESCRIPTION
## Summary
- adjust hero preload and image tags to use a smaller responsive size on larger screens

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894bc1cca908331a622744815e322a1