### PR TITLE
Fix hero image CLS with reserved aspect ratio

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,23 +111,18 @@
       #hero {
         position: relative;
         width: 100%;
-        height: 100vh;
         overflow: hidden;
       }
-      #hero .bg-image,
-      #hero .bg-gradient {
-        position: absolute;
-        inset: 0;
-        width: 100%;
-        height: 100%;
-      }
       #hero .bg-image {
+        position: relative;
+        width: 100%;
+        aspect-ratio: 1536 / 1024;
         clip-path: polygon(0 0, 100% 0, 50% 100%, 0 100%);
       }
       #hero .bg-image img {
+        object-fit: cover;
         width: 100%;
         height: 100%;
-        object-fit: cover;
         display: block;
       }
       #hero .bg-image::after {
@@ -139,6 +134,10 @@
         pointer-events: none;
       }
       #hero .bg-gradient {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
         background: linear-gradient(135deg, #ffa726, #fb8c00);
         clip-path: polygon(100% 0, 100% 100%, 50% 100%);
       }


### PR DESCRIPTION
## Summary
- prevent hero image CLS by reserving space with aspect-ratio container
- ensure hero image covers container and gradient overlay matches size

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68959a8c10b88331b4334181b99c7e11